### PR TITLE
Create Questions and Answers

### DIFF
--- a/verifact/error_strings.py
+++ b/verifact/error_strings.py
@@ -1,0 +1,3 @@
+URL_FORMAT_INVALID = "The citation url is not a valid url. Please remember to include the scheme (eg. https://)"
+ANSWER_CHOICES_INVALID = "Answer must be True, False, or Neither"
+QUESTION_ID_INVALID = "Ensure this Answer is created in response to a valid Question!"

--- a/verifact/forum/schema.py
+++ b/verifact/forum/schema.py
@@ -1,6 +1,11 @@
 from graphene import relay, ObjectType, Mutation
 from graphene import DateTime, String, Int, Field
 from graphene_django import DjangoObjectType
+import base64
+from graphql import GraphQLError
+from django.db import IntegrityError
+from django.core.validators import URLValidator
+from django.core.exceptions import ValidationError
 
 from .models import Question, Answer
 
@@ -42,12 +47,9 @@ class Query(ObjectType):
         return Answer.objects.all()
 
 
-# MUTATIONS
 
-
-class CreateQuestion(Mutation):
+class QuestionCreate(Mutation):
     class Arguments:
-        created_at = DateTime()
         text = String()
         citation_url = String()
         citation_title = String()
@@ -60,36 +62,32 @@ class CreateQuestion(Mutation):
         info,
         text,
         citation_url,
-        citation_title=None,
-        citation_image_url=None,
-        created_at=None,
+        citation_title="",
+        citation_image_url="",
     ):
+        val = URLValidator()
+        try:
+            val(citation_url)
+        except ValidationError:
+            raise GraphQLError('citationUrl has invalid format!')
         question = Question.objects.create(
-            created_at=created_at,
             text=text,
             citation_url=citation_url,
-            citation_title=citation_title
-            if citation_title is not None
-            else "Untitled",  # TODO: fetch with OpenGraph if not supplied, or in future more likely implement separate mutations to fetch OpenGraph metadata, then update with OpenGraph metadata if user is happy with it
+            citation_title=citation_title,
             citation_image_url=citation_image_url
-            if citation_image_url is not None
-            else "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Noun_Project_question_mark_icon_1101884_cc.svg/1024px-Noun_Project_question_mark_icon_1101884_cc.svg.png",  # TODO: same as 3 lines up, OpenGraph/metadata retrieval
-        )
+            )
 
         question.save()
-        return CreateQuestion(question=question)
+        return QuestionCreate(question=question)
 
 
-class CreateAnswer(Mutation):
+class AnswerCreate(Mutation):
     class Arguments:
-        created_at = DateTime()
         answer = String()
         text = String()
         citation_url = String()
         citation_title = String()
-        credible_count = Int()
-        not_credible_count = Int()
-        question_pk = Int()  # if switching to graphQL ID, switch to String
+        question_id = String()
 
     answer = Field(AnswerNode)
 
@@ -98,29 +96,38 @@ class CreateAnswer(Mutation):
         info,
         answer,
         text,
-        question_pk,
-        citation_url=None,
-        citation_title=None,
-        credible_count=0,
-        not_credible_count=0,
-        created_at=None,
+        question_id,
+        citation_url="",
+        citation_title="",
     ):
-        answer = Answer.objects.create(
-            answer=answer,
-            created_at=created_at,
-            text=text,
-            citation_url=citation_url,
-            citation_title=citation_title,
-            credible_count=credible_count,
-            not_credible_count=not_credible_count,
-            question=Question.objects.get(
-                pk=question_pk
-            ),  # should we use pk or graphQL ID? this uses pk. not sure how to fetch via graphql id though
-        )
-        answer.save()
-        return CreateAnswer(answer=answer)
+        val = URLValidator()
+        try:
+            val(citation_url)
+        except ValidationError:
+            raise GraphQLError('citationUrl has invalid format!')
+
+        try:
+            answer = Answer.objects.create(
+                answer=answer,
+                text=text,
+                citation_url=citation_url,
+                citation_title=citation_title,
+                credible_count=0,
+                not_credible_count=0,
+                question=Question.objects.get(
+                    pk=int(base64.b64decode(question_id.encode()).decode().split(':')[1])
+                ),
+            )
+            answer.save()
+        except IntegrityError as e:
+            if str(e.__cause__).startswith('new row for relation "forum_answer" violates check constraint "forum_answer_answer_valid"'): # this works but looks kinda bandaidy
+                raise GraphQLError('answer must be True, False, or Neither')
+            else:
+                raise
+
+        return AnswerCreate(answer=answer)
 
 
 class Mutation(ObjectType):
-    create_question = CreateQuestion.Field()
-    create_answer = CreateAnswer.Field()
+    question_create = QuestionCreate.Field()
+    answer_create = AnswerCreate.Field()

--- a/verifact/forum/schema.py
+++ b/verifact/forum/schema.py
@@ -49,7 +49,6 @@ class Query(ObjectType):
         return Answer.objects.all()
 
 
-
 class QuestionCreate(Mutation):
     class Arguments:
         text = String()
@@ -75,8 +74,8 @@ class QuestionCreate(Mutation):
             text=text,
             citation_url=citation_url,
             citation_title=citation_title,
-            citation_image_url=citation_image_url
-            )
+            citation_image_url=citation_image_url,
+        )
 
         question.save()
         return QuestionCreate(question=question)
@@ -114,11 +113,15 @@ class AnswerCreate(Mutation):
                 citation_title=citation_title,
                 credible_count=0,
                 not_credible_count=0,
-                question=Node.get_node_from_global_id(info, question_id, only_type = QuestionNode),
+                question=Node.get_node_from_global_id(
+                    info, question_id, only_type=QuestionNode
+                ),
             )
             answer.save()
         except IntegrityError as ie:
-            if str(ie.__cause__).startswith('new row for relation "forum_answer" violates check constraint "forum_answer_answer_valid"'): # this works but looks kinda bandaidy
+            if str(ie.__cause__).startswith(
+                'new row for relation "forum_answer" violates check constraint "forum_answer_answer_valid"'
+            ):
                 raise GraphQLError(error_strings.ANSWER_CHOICES_INVALID)
             else:
                 raise

--- a/verifact/forum/schema.py
+++ b/verifact/forum/schema.py
@@ -1,8 +1,7 @@
-from graphene import relay, ObjectType, Mutation
-from graphene import DateTime, String, Int, Field, ID
+from graphene import relay, ObjectType, String, Field, ID
+from graphene.relay import Node, ClientIDMutation
 from graphene_django import DjangoObjectType
 import base64
-from graphene.relay import Node
 from graphql import GraphQLError
 from django.db import IntegrityError
 from django.core.validators import URLValidator
@@ -49,22 +48,17 @@ class Query(ObjectType):
         return Answer.objects.all()
 
 
-class QuestionCreate(Mutation):
-    class Arguments:
+class QuestionCreate(ClientIDMutation):
+    question = Field(QuestionNode)
+
+    class Input:
         text = String()
         citation_url = String()
         citation_title = String()
         citation_image_url = String()
 
-    question = Field(QuestionNode)
-
-    def mutate(
-        self,
-        info,
-        text,
-        citation_url,
-        citation_title="",
-        citation_image_url="",
+    def mutate_and_get_payload(
+        self, info, text, citation_url, citation_title="", citation_image_url=""
     ):
         try:
             URLValidator(citation_url)
@@ -81,17 +75,17 @@ class QuestionCreate(Mutation):
         return QuestionCreate(question=question)
 
 
-class AnswerCreate(Mutation):
-    class Arguments:
+class AnswerCreate(ClientIDMutation):
+    answer = Field(AnswerNode)
+
+    class Input:
         answer = String()
         text = String()
         citation_url = String()
         citation_title = String()
         question_id = ID()
 
-    answer = Field(AnswerNode)
-
-    def mutate(
+    def mutate_and_get_payload(
         self,
         info,
         answer,

--- a/verifact/forum/schema.py
+++ b/verifact/forum/schema.py
@@ -1,4 +1,5 @@
-from graphene import relay, ObjectType
+from graphene import relay, ObjectType, Mutation
+from graphene import DateTime, String, Int, Field
 from graphene_django import DjangoObjectType
 
 from .models import Question, Answer
@@ -39,3 +40,87 @@ class Query(ObjectType):
 
     def resolve_answers(root, info):
         return Answer.objects.all()
+
+
+# MUTATIONS
+
+
+class CreateQuestion(Mutation):
+    class Arguments:
+        created_at = DateTime()
+        text = String()
+        citation_url = String()
+        citation_title = String()
+        citation_image_url = String()
+
+    question = Field(QuestionNode)
+
+    def mutate(
+        self,
+        info,
+        text,
+        citation_url,
+        citation_title=None,
+        citation_image_url=None,
+        created_at=None,
+    ):
+        question = Question.objects.create(
+            created_at=created_at,
+            text=text,
+            citation_url=citation_url,
+            citation_title=citation_title
+            if citation_title is not None
+            else "Untitled",  # TODO: fetch with OpenGraph if not supplied, or in future more likely implement separate mutations to fetch OpenGraph metadata, then update with OpenGraph metadata if user is happy with it
+            citation_image_url=citation_image_url
+            if citation_image_url is not None
+            else "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Noun_Project_question_mark_icon_1101884_cc.svg/1024px-Noun_Project_question_mark_icon_1101884_cc.svg.png",  # TODO: same as 3 lines up, OpenGraph/metadata retrieval
+        )
+
+        question.save()
+        return CreateQuestion(question=question)
+
+
+class CreateAnswer(Mutation):
+    class Arguments:
+        created_at = DateTime()
+        answer = String()
+        text = String()
+        citation_url = String()
+        citation_title = String()
+        credible_count = Int()
+        not_credible_count = Int()
+        question_pk = Int()  # if switching to graphQL ID, switch to String
+
+    answer = Field(AnswerNode)
+
+    def mutate(
+        self,
+        info,
+        answer,
+        text,
+        question_pk,
+        citation_url=None,
+        citation_title=None,
+        credible_count=0,
+        not_credible_count=0,
+        created_at=None,
+    ):
+        answer = Answer.objects.create(
+            answer=answer,
+            created_at=created_at,
+            text=text,
+            citation_url=citation_url,
+            citation_title=citation_title,
+            credible_count=credible_count,
+            not_credible_count=not_credible_count,
+            question=Question.objects.get(
+                pk=question_pk
+            ),  # should we use pk or graphQL ID? this uses pk. not sure how to fetch via graphql id though
+        )
+        answer.save()
+        return CreateAnswer(answer=answer)
+
+
+class Mutation(ObjectType):
+    create_question = CreateQuestion.Field()
+    create_answer = CreateAnswer.Field()

--- a/verifact/schema.py
+++ b/verifact/schema.py
@@ -8,5 +8,7 @@ class Query(ForumSchema.Query, graphene.ObjectType):
     # as we begin to add more apps to our project
     pass
 
+class Mutation(ForumSchema.Mutation, graphene.ObjectType):
+    pass
 
-schema = graphene.Schema(query=Query)
+schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/verifact/urls.py
+++ b/verifact/urls.py
@@ -14,11 +14,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import re_path
+from django.views.decorators.csrf import csrf_exempt
 
 from graphene_django.views import GraphQLView
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("graphql/", GraphQLView.as_view(graphiql=True)),
+    re_path("^admin/?", admin.site.urls),
+    re_path("^graphql/?", csrf_exempt(GraphQLView.as_view(graphiql=True))),
 ]


### PR DESCRIPTION
provides Mutation query support to create Question and Answers

currently, to create an Answer, the associated Question's `primary key` is supplied, instead of GraphQL ID.
also, when `citation_title` and `citation_url` is NOT supplied, default values are shown. Future support for metadata retrieval will be added as per Kanban board.

Sample Mutation query:

```
mutation{
  createAnswer(questionPk:2,answer:"False",text:"its false lmao",citationUrl:"hello.com",citationTitle:"Hello"){
    answer {
      id
    }
  }
}
```