### PR TITLE
Use global node interface instead of individual instances

### DIFF
--- a/verifact/forum/schema.py
+++ b/verifact/forum/schema.py
@@ -35,10 +35,7 @@ class AnswerConnection(relay.Connection):
 
 
 class Query(ObjectType):
-    question = relay.Node.Field(QuestionNode)
     questions = relay.ConnectionField(QuestionConnection)
-
-    answer = relay.Node.Field(AnswerNode)
     answers = relay.ConnectionField(AnswerConnection)
 
     def resolve_questions(root, info):

--- a/verifact/schema.py
+++ b/verifact/schema.py
@@ -4,11 +4,11 @@ import verifact.forum.schema as ForumSchema
 
 
 class Query(ForumSchema.Query, graphene.ObjectType):
-    # This class will inherit from multiple Queries
-    # as we begin to add more apps to our project
-    pass
+    node = graphene.relay.Node.Field()
+
 
 class Mutation(ForumSchema.Mutation, graphene.ObjectType):
     pass
+
 
 schema = graphene.Schema(query=Query, mutation=Mutation)


### PR DESCRIPTION
@jtan381 Based on our discussion on WhatsApp, hopefully this is clear. 

This adds a general `node` instead of requiring a new instance for each model type. It's a flexible way to allow querying any object that implements the `node` interface, which is convenient. It can be used in a query like this:

```
query {
  node (id: "UXVlc3Rpb25Ob2RlOjE=") {
    ... on QuestionNode {
      id
    }
  }
}
```


