### PR TITLE
restrict fields to username, id

### DIFF
--- a/verifact/graph/user/types.py
+++ b/verifact/graph/user/types.py
@@ -1,7 +1,7 @@
 from graphene_django import DjangoObjectType
 from django.contrib.auth.models import User
 
-
 class UserType(DjangoObjectType):
     class Meta:
         model = User
+        fields = ('username','id')


### PR DESCRIPTION
simple PR to whitelist the `username` and `id` fields when querying `user`.