### PR TITLE
prevent viewervote retrieval for anonymous users

### DIFF
--- a/verifact/forum/schema.py
+++ b/verifact/forum/schema.py
@@ -1,5 +1,4 @@
 from graphene import relay, ObjectType, String, Field, ID, Boolean, List, NonNull, JSONString
-from django.contrib.auth.models import AnonymousUser
 from graphene.relay import Node, Connection, ConnectionField, ClientIDMutation
 from graphql_relay.node.node import from_global_id
 from graphene_django import DjangoObjectType

--- a/verifact/forum/schema.py
+++ b/verifact/forum/schema.py
@@ -1,4 +1,5 @@
 from graphene import relay, ObjectType, String, Field, ID, Boolean, List, NonNull, JSONString
+from django.contrib.auth.models import AnonymousUser
 from graphene.relay import Node, Connection, ConnectionField, ClientIDMutation
 from graphql_relay.node.node import from_global_id
 from graphene_django import DjangoObjectType
@@ -66,7 +67,8 @@ class AnswerNode(DjangoObjectType):
 
     def resolve_viewer_vote(self, args):
         try:
-            return Vote.objects.get(answer=self, user=args.context.user)
+            if args.context.user.is_authenticated:
+                return Vote.objects.get(answer=self, user=args.context.user)
         except Vote.DoesNotExist:
             return None
 


### PR DESCRIPTION
simple fix to ensure that viewerVote retrieval is only attempted by authenticated users.

previously, when looking at an AnswerCard, a GraphQLLocatedError is raised stating that `AnonymousUser` object is not iterable. doesn't actually affect execution, but thought I'd just handle it.

changes here compatible with #19